### PR TITLE
change pipeline to target public pypi

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,5 +129,5 @@ jobs:
       displayName: 'Build stable python wheel from package source.'
 
     - script: |
-        python -m twine upload --username "__token__" --password $(TWINE_TOKEN) --verbose --repository testpypi dist/*
+        python -m twine upload --username "__token__" --password $(TWINE_TOKEN) --verbose dist/*
       displayName: 'Upload stable python wheel to test public pypi'


### PR DESCRIPTION
Update the `twine` command so that it targets the public python package index instead of the test server.