### PR TITLE
merge old commits from develop (no changes), bump matplotlib max vers…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = piblin
-version = 0.0.0a0
+version = 0.0.0a1
 description = Measurement data science functionality
 long_description = file: README.md
 project_urls = Source = https://github.com/3mcloud/piblin
@@ -34,7 +34,7 @@ license = Proprietary
 [options]
 zip_safe = false
 install_requires =
-    matplotlib<3.9.0
+    matplotlib<=3.9.2
     numpy>=1.21
     scipy
 python_requires = >=3.7,<3.12


### PR DESCRIPTION
Increases the maximum matplotlib version to the latest (3.9.2) to avoid compatibility issues with other packages. Bumps package version number by one alpha to 0.0.0a1.